### PR TITLE
Changed target framework to netstandard2.0

### DIFF
--- a/src/AspNetCore.Identity.Cassandra/AspNetCore.Identity.Cassandra.csproj
+++ b/src/AspNetCore.Identity.Cassandra/AspNetCore.Identity.Cassandra.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Lukas Kubis</Authors>
     <Company>Lukas Kubis</Company>


### PR DESCRIPTION
**Reason for change**: library cannot currently be used from within netstandard2.0 projects

**What was changed**: target framework for AspNetCore.Identity.Cassandra project was changed from netcoreapp2.0 to netstandard2.0

**Note**: i believe this change only affects availability of some APIs, given the fact that both projects build successfully, this change should not break anything